### PR TITLE
Bug: fix several bugs in TimedPipelie

### DIFF
--- a/dstoolbox/tests/test_pipeline.py
+++ b/dstoolbox/tests/test_pipeline.py
@@ -781,3 +781,14 @@ class TestTimedPipeline:
         assert lines[4] == expected[1]
         assert lines[7] == expected[2]
         assert lines[8] == expected[3]
+
+    def test_with_pipeline(self, timed_pipeline_cls, data, steps):
+        # Currently, sklearn's Pipeline.transform is a property!
+        X, y = data
+        timed_pipeline = timed_pipeline_cls([
+            ('step0', Pipeline(steps))
+        ])
+        timed_pipeline.fit(X, y)
+        timed_pipeline.transform(X)
+        timed_pipeline.shed_timing()
+        timed_pipeline.transform(X)

--- a/dstoolbox/tests/test_pipeline.py
+++ b/dstoolbox/tests/test_pipeline.py
@@ -782,6 +782,30 @@ class TestTimedPipeline:
         assert lines[7] == expected[2]
         assert lines[8] == expected[3]
 
+    def test_excess_add_timing(self, timed_pipeline, data, expected):
+        sink = timed_pipeline.sink
+        X, y = data
+
+        timed_pipeline.add_timing()
+        timed_pipeline.fit(X, y).predict(X)
+
+        lines = [c[0][0] for c in sink.call_args_list]
+        assert len(lines) == 3 + 3 + 1 + 1 + 1 + 1
+        self.assert_lines_correct_form(lines)
+        assert lines[1] == expected[0]
+        assert lines[4] == expected[1]
+        assert lines[7] == expected[2]
+        assert lines[8] == expected[3]
+
+    def test_excess_shed_timing(self, timed_pipeline, data):
+        sink = timed_pipeline.sink
+        X, y = data
+
+        timed_pipeline.shed_timing()
+        timed_pipeline.shed_timing()
+        timed_pipeline.fit(X, y).predict(X)
+        assert sink.call_count == 0
+
     def test_with_pipeline(self, timed_pipeline_cls, data, steps):
         # Currently, sklearn's Pipeline.transform is a property!
         X, y = data


### PR DESCRIPTION
Errors caused by

* calling `add_timing` more than once,
* calling `shed_timing` more than once,
* sklearn's pipeline's transform method being a [property](https://github.com/scikit-learn/scikit-learn/blob/14031f6/sklearn/pipeline.py#L419) at the moment 

are being fixed.

Addresses issue here: https://github.com/ottogroup/dstoolbox/issues/6