### PR TITLE
Unpin sklearn requirement inside of setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('VERSION', 'r') as f:
 install_requires = [
     'numpy',
     'pandas',
-    'scikit-learn==0.19',
+    'scikit-learn>=0.19,<0.20dev0',
     'scipy',
     ]
 


### PR DESCRIPTION
This makes it impossible to install dstoolbox with, say, sklearn
0.19.1.  I believe the intention here is to require 0.19 at a minimum
since we depend on a specific API that was introduced in this version?